### PR TITLE
Added parser to datetime and decimal to json and force cast 'path' to string;

### DIFF
--- a/firebase/__init__.py
+++ b/firebase/__init__.py
@@ -18,6 +18,7 @@ class JSONEncoder(json.JSONEncoder):
 
 class Firebase():
     ROOT_URL = '' #no trailing slash
+    auth_token = None
 
     def __init__(self, root_url, auth_token=None):
         self.ROOT_URL = root_url.rstrip('/')
@@ -28,7 +29,7 @@ class Firebase():
     def child(self, path):
         root_url = '%s/' % self.ROOT_URL
         url = urlparse.urljoin(root_url, str(path).lstrip('/'))
-        return Firebase(url)
+        return Firebase(url, auth_token=self.auth_token)
 
     def parent(self):
         url = os.path.dirname(self.ROOT_URL)
@@ -36,7 +37,7 @@ class Firebase():
         up = urlparse.urlparse(url)
         if up.path == '':
             return None #maybe throw exception here?
-        return Firebase(url)
+        return Firebase(url, auth_token=self.auth_token)
 
     def name(self):
         return os.path.basename(self.ROOT_URL)

--- a/firebase/__init__.py
+++ b/firebase/__init__.py
@@ -2,8 +2,19 @@ import requests
 import urlparse #for urlparse and urljoin
 import os #for os.path.dirname
 import json #for dumps
+import datetime #for parse datetime object to string
+import decimal #for parse decimal to string
 
-
+class JSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime.datetime):
+            return obj.isoformat()
+        elif isinstance(obj, datetime.timedelta):
+            return total_seconds(obj)
+        elif isinstance(obj, decimal.Decimal):
+            return float(obj)
+        else:
+            return json.JSONEncoder.default(self, obj)
 
 class Firebase():
     ROOT_URL = '' #no trailing slash
@@ -75,7 +86,7 @@ class Firebase():
         #Firebase API does not accept form-encoded PUT/POST data. It needs to
         #be JSON encoded.
         if 'data' in kwargs:
-            kwargs['data'] = json.dumps(kwargs['data'])
+            kwargs['data'] = json.dumps(kwargs['data'], cls=JSONEncoder)
 
         params = {}
         if self.auth_token:

--- a/firebase/__init__.py
+++ b/firebase/__init__.py
@@ -27,7 +27,7 @@ class Firebase():
 
     def child(self, path):
         root_url = '%s/' % self.ROOT_URL
-        url = urlparse.urljoin(root_url, path.lstrip('/'))
+        url = urlparse.urljoin(root_url, str(path).lstrip('/'))
         return Firebase(url)
 
     def parent(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests >=1.2.0,<1.2.99
+requests >=1.2.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author = 'Michael Huynh',
     author_email = 'mike@mikexstudios.com',
     url = 'http://github.com/mikexstudios/python-firebase',
-    install_requires = ['requests >=1.2.0,<1.2.99'], 
+    install_requires = ['requests >=1.2.0'], 
     classifiers = [
         'Programming Language :: Python', 
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
I have a basic dict as follows:

```
sample = {}
sample['title'] = "String"
sample['somedate'] = somedatetimehere - example: datetime.now()
```

When I try to do jsonify(sample) I get:

```
TypeError: datetime.datetime(2012, 8, 8, 21, 46, 24, 862000) is not JSON serializable
```

---

AttributeError: 'int' object has no attribute 'lstrip'
