### PR TITLE
Adding auth_token when creating a new instance

### DIFF
--- a/firebase/__init__.py
+++ b/firebase/__init__.py
@@ -17,7 +17,10 @@ class Firebase():
     def child(self, path):
         root_url = '%s/' % self.ROOT_URL
         url = urlparse.urljoin(root_url, path.lstrip('/'))
-        return Firebase(url)
+        if self.auth_token:
+            return Firebase(url, auth_token=self.auth_token)
+        else:
+            return Firebase(url)
 
     def parent(self):
         url = os.path.dirname(self.ROOT_URL)
@@ -25,7 +28,10 @@ class Firebase():
         up = urlparse.urlparse(url)
         if up.path == '':
             return None #maybe throw exception here?
-        return Firebase(url)
+        if self.auth_token:
+            return Firebase(url, auth_token=self.auth_token)
+        else:
+            return Firebase(url)
 
     def name(self):
         return os.path.basename(self.ROOT_URL)


### PR DESCRIPTION
When calling ```child``` or ```parent``` methods it will raise an exception if there exists an ```auth_token``` when trying to access to the content via ```get```:

    HTTPError: 401 Client Error: Unauthorized